### PR TITLE
Add vitest config and shuffleArray tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.4",
@@ -24,6 +25,10 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "jsdom": "^24.0.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
     "vite": "^6.3.1"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import allQuestions from './questions.json';
 
-function shuffleArray(array) {
+export function shuffleArray(array) {
   const shuffled = [...array];
   for (let i = shuffled.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));

--- a/src/__tests__/shuffleArray.test.js
+++ b/src/__tests__/shuffleArray.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { shuffleArray } from '../App.jsx';
+
+describe('shuffleArray', () => {
+  it('returns a permutation of the input array and has the same length', () => {
+    const input = [1, 2, 3, 4, 5];
+    const output = shuffleArray(input);
+    expect(output).toHaveLength(input.length);
+    expect(output.sort()).toEqual([...input].sort());
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react-swc'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+  },
 })


### PR DESCRIPTION
## Summary
- export `shuffleArray` from `App.jsx`
- configure vitest with jsdom in `vite.config.js`
- add a basic shuffleArray test
- add vitest and testing-library dev deps
- add `npm test` script

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406607bab48325bc1550ece982e02e